### PR TITLE
Add "User-Agent" header to HTTP download request

### DIFF
--- a/SpeedTest.Net/BaseHttpClient.cs
+++ b/SpeedTest.Net/BaseHttpClient.cs
@@ -51,7 +51,10 @@ namespace SpeedTest.Net
             {
                 DeleteFile(tempFile);
 
-                using (HttpResponseMessage response = await GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead))
+                var request = new HttpRequestMessage(HttpMethod.Get, downloadUrl) { Version = DefaultRequestVersion };
+                request.Headers.Add("User-Agent", "SpeedTest.Net"); 
+                
+                using (HttpResponseMessage response = await SendAsync(request, HttpCompletionOption.ResponseHeadersRead))
                 {
                     var cancellationTokenSource = new CancellationTokenSource();
                     cancellationTokenSource.CancelAfter(timeout);

--- a/SpeedTest.Net/BaseHttpClient.cs
+++ b/SpeedTest.Net/BaseHttpClient.cs
@@ -51,10 +51,9 @@ namespace SpeedTest.Net
             {
                 DeleteFile(tempFile);
 
-                var request = new HttpRequestMessage(HttpMethod.Get, downloadUrl) { Version = DefaultRequestVersion };
-                request.Headers.Add("User-Agent", "SpeedTest.Net"); 
-                
-                using (HttpResponseMessage response = await SendAsync(request, HttpCompletionOption.ResponseHeadersRead))
+                DefaultRequestHeaders.Add("User-Agent", "SpeedTest.Net"); 
+
+                using (HttpResponseMessage response = await GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead))
                 {
                     var cancellationTokenSource = new CancellationTokenSource();
                     cancellationTokenSource.CancelAfter(timeout);

--- a/SpeedTest.Net/BaseHttpClient.cs
+++ b/SpeedTest.Net/BaseHttpClient.cs
@@ -51,7 +51,10 @@ namespace SpeedTest.Net
             {
                 DeleteFile(tempFile);
 
-                DefaultRequestHeaders.Add("User-Agent", "SpeedTest.Net"); 
+                if (DefaultRequestHeaders.UserAgent.Count == 0)
+                {
+                    DefaultRequestHeaders.Add("User-Agent", "SpeedTest.Net");
+                }
 
                 using (HttpResponseMessage response = await GetAsync(downloadUrl, HttpCompletionOption.ResponseHeadersRead))
                 {


### PR DESCRIPTION
Upon trying to use `SpeedTestClient.GetDownloadSpeed()` I've repeatedly received the message `Response status code does not indicate success: 500 (Internal Server Error).` which had been written to the console. This problem didn't occur using either Chrome or Postman. After some trial and error, I've found out that by adding the `User-Agent` header to the HTTP download request (with an arbitrary value) this problem can be avoided. This, however, forced a change in the `GetDownloadedBytes` method - since a request's header cannot be manipulated using `GetAsync` (a method from the base class), I now use `SendAsync` instead.

Admittedly, I've only tested this on my own PC, so I'm not 100% sure whether or not this has any other implications. However, this change seems to fix the problem when using any SpeedTest server I was previously receiving a `500 Internal Server Error` response from.